### PR TITLE
Switch to koa/cors library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,11 @@
         }
       }
     },
+    "@koa/cors": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-2.2.2.tgz",
+      "integrity": "sha512-Ollvsy3wB8+7R9w6hPVzlj3wekF6nK+IHpHj7faSPVXCkahqCwNEPp9+0C4b51RDkdpHjevLEGLOKuVjqtXgSQ=="
+    },
     "@rgrove/parse-xml": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-1.1.1.tgz",
@@ -146,6 +151,15 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@types/koa-send/-/koa-send-4.1.1.tgz",
       "integrity": "sha512-ODeofnQxlkAl5PvJXhgOF/hjX9cH47oDFDqH9nE0G6zcp/Rr0vjswe7tuA+b0ZhlBrkfmN9X8VhRqQCBeOtZrw==",
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
+    "@types/koa__cors": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-2.2.3.tgz",
+      "integrity": "sha512-RfG2EuSc+nv/E+xbDSLW8KCoeri/3AkqwVPuENfF/DctllRoXhooboO//Sw7yFtkLvj7nG7O1H3JcZmoTQz8nQ==",
+      "dev": true,
       "requires": {
         "@types/koa": "*"
       }
@@ -2388,11 +2402,6 @@
           }
         }
       }
-    },
-    "koa-cors": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/koa-cors/-/koa-cors-0.0.16.tgz",
-      "integrity": "sha1-mBB5k6eQnjTAQphsXsYVbXfzQy4="
     },
     "koa-is-json": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/koa": "^2.0.47",
     "@types/koa-route": "^3.2.4",
+    "@types/koa__cors": "^2.2.2",
     "@types/node": "^10.12.10",
     "@types/shelljs": "^0.8.0",
     "nodemon": "^1.18.7",
@@ -40,7 +41,7 @@
     "@rgrove/parse-xml": "^1.1.1",
     "@types/koa-send": "^4.1.1",
     "koa": "^2.6.2",
-    "koa-cors": "0.0.16",
+    "@koa/cors": "^2.2.2",
     "koa-route": "^3.2.0",
     "koa-send": "^5.0.0",
     "ts-node": "^7.0.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as Koa from 'koa';
 import * as route from 'koa-route';
 import * as send from 'koa-send';
-import * as cors from 'koa-cors';
+import * as cors from '@koa/cors';
 import { openBook, library } from './openBook';
 
 const port = process.env.PORT || 3042;
@@ -28,7 +28,7 @@ function serveFile(f: (name: string) => string) {
     return async (ctx, name: string) => {
         const fileName = f(name);
         const ext = fileName.split('.').pop();
-        ctx.set('Content-Disposition', `attachment; filename="${name}.${ext}"`);
+        ctx.attachment(`${name}.${ext}`);
         await send(ctx, fileName);
     };
 }

--- a/src/openBook.ts
+++ b/src/openBook.ts
@@ -52,7 +52,7 @@ export async function openBook(bookName: string): Promise<ActualBook | undefined
     if (await exists(epubPath(bookName))) { // Check if epub file exist
         const epubFile = await readFile(epubPath(bookName));
         const book = await buffer2book(epubFile);
-        writeJson(bookCachePath(bookName), book);
+        await writeJson(bookCachePath(bookName), book);
 
         return book;
     }
@@ -81,7 +81,7 @@ function epubPath(bookName: string) {
 }
 
 function bookCachePath(bookName: string) {
-    return staticLocation + cacheLocation + epubLocation + bookName + '.json';
+    return staticLocation + cacheLocation + bookName + '.json';
 }
 
 const exists = promisify(fs.exists);


### PR DESCRIPTION
This should get rid of those koa warnings on build

Closes #17 **?**

Proposed changes:
- Switch to the koa/cors library, which is (more) compliant with the latest koa